### PR TITLE
Use full title for tuning_guide

### DIFF
--- a/_data/locales/en.yml
+++ b/_data/locales/en.yml
@@ -23,7 +23,7 @@ startup_guide: Startup Guide
 gnome_user_guide: GNOME User Guide
 reference_guide: Reference Guide
 security_guide: Security Guide
-tuning_guide: Tuning Guide
+tuning_guide: System Analysis and Tuning Guide
 virtualization_guide: Virtualization Guide
 autoyast_guide: AutoYaST Guide
 release_notes: Release Notes


### PR DESCRIPTION
Cross-book references, which are not hyperlinks, refer to the book  _System Analysis and Tuning Guide_, which is nowhere to be found, at least from the index page, especially since the abbreviation that was used starts in the middle of the title.  See &rarr; https://github.com/SUSE/doc-sle/pull/977#event-5457513416