### PR TITLE
Fix broken single-html links for Leap 15.4

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -168,21 +168,21 @@ opensuse_versions:
         id: gnome_user_guide
         cover: /assets/images/cover-gnome.svg
         html: https://doc.opensuse.org/documentation/leap/archive/15.4/gnome-user/html/book-gnome-user/index.html
-        single_html: https://doc.opensuse.org/documentation/archive/15.4/leap/gnome-user/single-html/book-gnome-user/index.html
+        single_html: https://doc.opensuse.org/documentation/leap/archive/15.4/gnome-user/single-html/book-gnome-user/index.html
         pdf: https://doc.opensuse.org/documentation/leap/archive/15.4/gnome-user/book-gnome-user_color_en.pdf
         epub: https://doc.opensuse.org/documentation/leap/archive/15.4/gnome-user/book-gnome-user_en.epub
       -
         id: reference_guide
         cover: /assets/images/cover-reference.svg
         html: https://doc.opensuse.org/documentation/leap/archive/15.4/reference/html/book-reference/index.html
-        single_html: https://doc.opensuse.org/documentation/archive/15.4/leap/reference/single-html/book-reference/index.html
+        single_html: https://doc.opensuse.org/documentation/leap/archive/15.4/reference/single-html/book-reference/index.html
         pdf: https://doc.opensuse.org/documentation/leap/archive/15.4/reference/book-reference_color_en.pdf
         epub: https://doc.opensuse.org/documentation/leap/archive/15.4/reference/book-reference_en.epub
       -
         id: security_guide
         cover: /assets/images/cover-security.svg
         html: https://doc.opensuse.org/documentation/leap/archive/15.4/security/html/book-security/index.html
-        single_html: https://doc.opensuse.org/documentation/archive/15.4/leap/security/single-html/book-security/index.html
+        single_html: https://doc.opensuse.org/documentation/leap/archive/15.4/security/single-html/book-security/index.html
         pdf: https://doc.opensuse.org/documentation/leap/archive/15.4/security/book-security_color_en.pdf
         epub: https://doc.opensuse.org/documentation/leap/archive/15.4/security/book-security_en.epub
       -
@@ -203,7 +203,7 @@ opensuse_versions:
         id: autoyast_guide
         cover: /assets/images/cover-autoyast.svg
         html: https://doc.opensuse.org/documentation/leap/archive/15.4/autoyast/html/book-autoyast/index.html
-        single_html: https://doc.opensuse.org/documentation/archive/15.4/leap/autoyast/single-html/book-autoyast/index.html
+        single_html: https://doc.opensuse.org/documentation/leap/archive/15.4/autoyast/single-html/book-autoyast/index.html
         pdf: https://doc.opensuse.org/documentation/leap/archive/15.4/autoyast/book-autoyast_color_en.pdf
         epub: https://doc.opensuse.org/documentation/leap/archive/15.4/autoyast/book-autoyast_en.epub
   -


### PR DESCRIPTION
Hello folks,

Currently we have broken links for the following **Single HTML** *Leap 15.4* docs:

- GNOME User;
- Reference;
- Security; and
- AutoYaST.

Thanks to James Arvold for reporting the issue.