### PR TITLE
Update howto for publising of index page poo#162020

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ upload: build publishusers
 	test -s $(userconfig) && source $(userconfig); \
 	if [[ $$userdoc ]] && [[ $$port ]] && [[ $$server ]]; then \
 	  echo "Syncing documentation."; \
-	  rsync -lr -v "_site/" -e "ssh -p $$port" $${userdoc}@$${server}:doc.opensuse.org/htdocs/ ; \
+#	  rsync -lr -v "_site/" -e "ssh -p $$port" $${userdoc}@$${server}:doc.opensuse.org/htdocs/ ; \
+	  rsync -lr -v "_site/" -e "ssh -p $$port" $${userdoc}@$${server}:/srv/www/vhosts-legacy/doc-htdocs/ ; \
 	else \
 	  exit 1; \
 	fi

--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ Such configuration then needs to be deployed to pinot-i-o-o.
 
 ### Syncing documentation navigation
 
-```bash
-make upload
-```
+The make upload no longer works as community was decomissioned.
+See [poo#162020](https://progress.opensuse.org/issues/162020) ticket for fixing of the process.
+
+Make a local build && create archive of the "_site" build dir.
+Extract _site archive or rsync _site/* into community2.infra.opensuse.org:/srv/www/vhosts-legacy/doc-htdocs/
+Ask admin@opensuse.org for root access or ping lkocman.
+
 
 ### Syncing configuration for the release notes
 

--- a/publishusers
+++ b/publishusers
@@ -1,5 +1,5 @@
 port=22
-server=community.infra.opensuse.org
+server=community2.infra.opensuse.org
 userdoc=lxbuch
 userrn=relsync
 version=15.6


### PR DESCRIPTION
publishing of doc-o-o index page needs to be reworked since the community.i.o.o one was decomissioned. And legacy workflow was moved to community2.i.o.o

See https://progress.opensuse.org/issues/162020

The doc.o.o index is now living in community2:/srv/www/vhosts-legacy/doc-htdocs

For 15.6 I've updated it manually with scp && root manually via extraction of a locally build _site

