### PR TITLE
Remove extra bullet point in openSUSE versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -154,7 +154,6 @@ opensuse_versions:
         pdf: https://doc.opensuse.org/documentation/leap/autoyast/book-autoyast_en.pdf
         epub: https://doc.opensuse.org/documentation/leap/autoyast/book-autoyast_en.epub
   -
-  -
     version: Leap 15.5
     docs:
       -


### PR DESCRIPTION
On doc.opensuse.org, below the documentation for Leap 15.6 we have:

![immagine](https://github.com/user-attachments/assets/a2a940ff-3ff6-4ab7-8eb4-303bf5d0dd05)
