### PR TITLE
Fix rpm name for Leap 15.6

### DIFF
--- a/rn-config/etc/releasenotes
+++ b/rn-config/etc/releasenotes
@@ -17,4 +17,4 @@
 # TODO: phase out factory and only provide Tumbleweed
 obs://Documentation:Auto/openSUSE_Factory|openSUSE|factory|release-notes-openSUSE-TW|x86_64|
 obs://Documentation:Auto/openSUSE_Factory|openSUSE|Tumbleweed|release-notes-openSUSE-TW|x86_64|
-obs://Documentation:Auto/openSUSE_Leap_15.6|openSUSE|Leap/15.6|release-notes-openSUSE-L155|x86_64|
+obs://Documentation:Auto/openSUSE_Leap_15.6|openSUSE|Leap/15.6|release-notes-openSUSE-L156|x86_64|


### PR DESCRIPTION
* Correct name is release-notes-openSUSE-L156